### PR TITLE
fix footer typo

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -120,7 +120,7 @@ export default class extends Component<{}, State> {
                     href="https://docs.actionherojs.com"
                     style={footerLinkStyle}
                   >
-                    Documenation
+                    Documentation
                   </a>
                 </p>
                 <p>


### PR DESCRIPTION
I was reading the website's docs and I saw a typo on the Documentation link in the footer